### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 数据结构与算法的JavaScript实现及应用
 =====
-##文章
+## 文章
 * [数据结构与算法的JavaScript实现及应用 – 单链表](http://wuzhiwei.net/ds_app_linkedlist/)
 * [数据结构与算法的JavaScript实现及应用 – 栈 递归 汉诺塔](http://wuzhiwei.net/ds_app_stack/)
 * [数据结构与算法的JavaScript实现及应用 – 二叉查找树](http://wuzhiwei.net/ds_app_bst/)
 * [牛顿法与自动求解器](http://wuzhiwei.net/newton_method_auto_solver/)
 * [利用向量运算解决圆线碰撞问题](http://wuzhiwei.net/vector_circle_line_collide/)
 
-##DEMO in HTML5
+## DEMO in HTML5
 * [简易多项式运算](http://jsfiddle.net/timwzw/ZFprM/)
 * [简易计算器](http://jsfiddle.net/timwzw/66GDv/)
 * [汉诺塔](http://jsfiddle.net/timwzw/S7mYF/)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
